### PR TITLE
variable for connection renamed, explanation updated

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,10 +22,10 @@ const db = new Sequelize('postgres://localhost:5432/your-db')
 
 # Your first model
 
-Models are defined with `sequelize.define('name', {attributes}, {options})`.
+Models are defined with the `.define()` method: `db.define('name', {attributes}, {options})`.
 
 ```js
-const User = sequelize.define('user', {
+const User = db.define('user', {
   firstName: {
     type: Sequelize.STRING
   },


### PR DESCRIPTION
Suggestion: Logically, since this code snippet appears in context with 'new Sequelize('...')' stored in the variable called 'db', it makes a bit more sense to continue with the same variable name, instead of bringing in a variable called 'sequelize' without showing how and when it's being assigned.